### PR TITLE
Fixes malformed icon76 image path in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "icons": {
     "250": "/images/icon250.png",
     "128": "/images/icon128.png",
-    "76": "/iamges/icon/76.png",
+    "76": "/images/icon76.png",
     "48": "/images/icon48.png",
     "38": "/images/icon76.png",
     "19": "/images/icon19.png",


### PR DESCRIPTION
When attempting to install the extension from the Chrome extension store, all users are greeted with the following error due to a malformed image path (specifically for `icon76.png`) in `manifest.json`. This results in all users being unable to install this extension from the Chrome store unless they navigate to this repository, clone it down, fix the path themselves, and then locally load the extension.

<img width="983" alt="screen shot 2016-04-24 at 5 05 59 pm" src="https://cloud.githubusercontent.com/assets/2636611/14770403/ec77de96-0a3e-11e6-9b96-af293eeab884.png">

The image path is currently defined as `/iamges/icon/76.png` when it should really be `/images/icon76.png` (which this PR will address)
